### PR TITLE
feat(fix): autofix using `--replace` and history

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ The prompt also provides fuzzy matched suggestions when typing the icon name:
 You can also use the `search` command to call the prompt directly for fuzzy
 search.
 
+### Autofix
+
+`nerdfix` provides some features to autofix obsolete icons:
+
+- The last input is picked if an icon appears twice.
+- Use `--replace FROM,TO` to replace the prefix of an icon name with another,
+  e.g. `nf-mdi-tab` is replaced by `nf-md-tab` when `--replace nf-mdi-,nf-md-`
+  is specified.
+
 ## ⚖️ License
 
 Licensed under either of

--- a/cspell.json
+++ b/cspell.json
@@ -1,1 +1,1 @@
-{"version":"0.2","flagWords":[],"language":"en","words":["nerdfix","codepoint","codepoints"]}
+{"flagWords":[],"language":"en","words":["nerdfix","codepoint","codepoints","autofix"],"version":"0.2"}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,9 +41,9 @@ pub enum Command {
         /// Auto-confirm interactive prompts.
         #[arg(short, long)]
         yes: bool,
-        /// Replace the prefix of a icon with another.
+        /// Replace the prefix of an icon name with another.
         ///
-        /// For example, use `--replace nf-mdi,nf-md` to replace all `nf-mdi*` icons
+        /// For example, use `--replace nf-mdi-,nf-md-` to replace all `nf-mdi*` icons
         /// with the same icons in `nf-md*`.
         #[arg(short, long, value_name(V_REPLACE))]
         replace: Vec<Replace>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,8 @@ pub struct Cli {
     /// Path(s) to load the icons cheat sheet or cached content.
     #[arg(short, long, value_name(V_PATH))]
     pub input: Vec<PathBuf>,
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    pub verbose: u8,
     #[command(subcommand)]
     pub cmd: Command,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@ use std::{path::PathBuf, str::FromStr};
 use thisctx::IntoError;
 
 const V_PATH: &str = "PATH";
+const V_REPLACE: &str = "CLASSES";
 
 #[derive(Debug, Parser)]
 pub struct Cli {
@@ -38,6 +39,12 @@ pub enum Command {
         /// Auto-confirm interactive prompts.
         #[arg(short, long)]
         yes: bool,
+        /// Replace the prefix of a icon with another.
+        ///
+        /// For example, use `--replace nf-mdi,nf-md` to replace all `nf-mdi*` icons
+        /// with the same icons in `nf-md*`.
+        #[arg(short, long, value_name(V_REPLACE))]
+        replace: Vec<Replace>,
     },
     /// Fuzzy search for an icon.
     Search {},
@@ -69,5 +76,25 @@ impl FromStr for UserInput {
         } else {
             Ok(Self::Name(s.to_owned()))
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Replace {
+    pub from: String,
+    pub to: String,
+}
+
+impl FromStr for Replace {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (from, to) = s
+            .split_once(',')
+            .ok_or("the input should be two classes separated by a comma")?;
+        Ok(Self {
+            from: from.to_owned(),
+            to: to.to_owned(),
+        })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,18 +13,25 @@ use cli::Command;
 use prompt::YesOrNo;
 use runtime::{CheckerContext, Runtime};
 use thisctx::WithContext;
-use tracing::error;
+use tracing::{error, Level};
 
 static CACHED: &str = include_str!("./cached.txt");
 
 fn main_impl() -> error::Result<()> {
+    let args = cli::Cli::parse();
+
+    let lv = match args.verbose {
+        0 => Level::WARN,
+        1 => Level::INFO,
+        2 => Level::DEBUG,
+        _ => Level::TRACE,
+    };
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
-        .with_max_level(tracing::Level::WARN)
+        .with_max_level(lv)
         .without_time()
         .finish();
     tracing::subscriber::set_global_default(subscriber).context(error::Any)?;
 
-    let args = cli::Cli::parse();
     let mut rt = Runtime::builder();
     if args.input.is_empty() {
         rt.load_cache(CACHED);

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,0 +1,44 @@
+use crate::error;
+use inquire::InquireError;
+use std::{fmt, str::FromStr};
+use thisctx::{IntoError, WithContext};
+
+pub fn prompt_yes_or_no(msg: &str, help: Option<&str>) -> error::Result<YesOrNo> {
+    match inquire::CustomType::<YesOrNo>::new(msg)
+        .with_help_message(help.unwrap_or("Yes/No/All yes, <Ctrl-C> to abort"))
+        .prompt()
+    {
+        Err(InquireError::OperationInterrupted) => error::Interrupted.fail(),
+        t => t.context(error::Prompt),
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum YesOrNo {
+    Yes,
+    No,
+    AllYes,
+}
+
+impl fmt::Display for YesOrNo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            YesOrNo::Yes => write!(f, "yes"),
+            YesOrNo::No => write!(f, "no"),
+            YesOrNo::AllYes => write!(f, "all yes"),
+        }
+    }
+}
+
+impl FromStr for YesOrNo {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "y" | "yes" => Ok(Self::Yes),
+            "n" | "no" => Ok(Self::No),
+            "a" | "all" => Ok(Self::AllYes),
+            _ => Err("invalid input"),
+        }
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -65,7 +65,7 @@ impl Runtime {
                         end += 1;
                     }
                     let candidates = self.candidates(icon)?;
-                    let diag = Diagnostic::warning()
+                    let diag = Diagnostic::note()
                         .with_message(format!("Found obsolete icon U+{:X}", icon.codepoint as u32))
                         .with_labels(vec![Label::primary(file_id, start..end)
                             .with_message(format!("Icon '{}' is marked as obsolete", icon.name))])

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,6 +1,6 @@
 use crate::{
     autocomplete::Autocompleter,
-    cli::UserInput,
+    cli::{Replace, UserInput},
     error,
     icon::{CachedIcon, Icon},
 };
@@ -14,11 +14,12 @@ use indexmap::IndexMap;
 use inquire::InquireError;
 use ngrammatic::{Corpus, CorpusBuilder};
 use once_cell::unsync::OnceCell;
-use std::{collections::HashMap, fmt, path::Path, rc::Rc, str::FromStr};
+use std::{collections::HashMap, path::Path, rc::Rc};
 use thisctx::{IntoError, WithContext};
+use tracing::warn;
 
 const SIMILARITY: f32 = 0.75;
-const MAX_CHOICES: usize = 7;
+const MAX_CHOICES: usize = 4;
 
 pub type FstSet = fst::Set<Vec<u8>>;
 
@@ -51,18 +52,11 @@ impl Runtime {
         path: &Path,
         does_fix: bool,
     ) -> error::Result<Option<String>> {
-        macro_rules! report {
-            ($diag:expr) => {
-                term::emit(&mut context.writer, &context.config, &context.files, $diag)
-                    .context(error::Reporter)?;
-            };
-        }
-
         let mut result = None::<String>;
         let content = std::fs::read_to_string(path).context(error::Io(path))?;
         let file_id = context.files.add(path.display().to_string(), content);
         let content = context.files.get(file_id).unwrap().source();
-        for (start, ch) in content.char_indices() {
+        for (start, mut ch) in content.char_indices() {
             if let Some(&icon) = self.index().get(&ch) {
                 let icon = &self.icons[icon];
                 if icon.obsolete {
@@ -70,24 +64,31 @@ impl Runtime {
                     while !content.is_char_boundary(end) {
                         end += 1;
                     }
+                    let candidates = self.candidates(icon)?;
                     let diag = Diagnostic::warning()
                         .with_message(format!("Found obsolete icon U+{:X}", icon.codepoint as u32))
                         .with_labels(vec![Label::primary(file_id, start..end)
-                            .with_message(format!("Icon '{}' is marked as obsolete", icon.name))]);
+                            .with_message(format!("Icon '{}' is marked as obsolete", icon.name))])
+                        .with_notes(self.diagnostic_notes(&candidates)?);
+                    term::emit(&mut context.writer, &context.config, &context.files, &diag)
+                        .context(error::Reporter)?;
+                    // Autofix use history.
                     if let Some(&last) = context.history.get(&icon.codepoint) {
-                        report!(&diag);
-                        cprintln!("# Auto patch using last input '{}'".green, last);
+                        cprintln!("# Auto fix it using last input '{}'".green, last);
+                        ch = last;
+                    // Autofix use replacing.
+                    } else if let Some(new) = self.try_replace(context, icon) {
+                        cprintln!("# Auto replace it with '{}'".green, new);
+                        ch = new;
                     } else {
-                        let candidates = self.candidates(icon)?;
-                        report!(&diag.with_notes(self.diagnostic_notes(&candidates)?));
                         // Input a new icon
                         if does_fix {
+                            // Push all non-patched content.
                             let res = result.get_or_insert_with(|| content[..start].to_owned());
                             match self.prompt_input_icon(Some(&candidates)) {
-                                Ok(Some(ch)) => {
-                                    res.push(ch);
-                                    context.history.insert(icon.codepoint, ch);
-                                    continue;
+                                Ok(Some(new)) => {
+                                    context.history.insert(icon.codepoint, new);
+                                    ch = new;
                                 }
                                 Ok(None) => (),
                                 Err(error::Error::Interrupted) => {
@@ -100,13 +101,25 @@ impl Runtime {
                     }
                 }
             }
-            // Save other characters.
+            // Save the new character.
             if let Some(res) = result.as_mut() {
                 res.push(ch);
             }
         }
 
         Ok(result)
+    }
+
+    fn try_replace(&self, ctx: &CheckerContext, icon: &Icon) -> Option<char> {
+        for rep in ctx.replace.iter() {
+            let Some(name) = icon.name.strip_prefix(&rep.from) else { continue };
+            let Some(new_icon) = self.icons.get(&format!("{}{name}", rep.to)) else {
+                warn!("{} cannot be replaced with '{}*'", icon.name, rep.to);
+                continue;
+            };
+            return Some(new_icon.codepoint);
+        }
+        None
     }
 
     fn candidates(&self, icon: &Icon) -> error::Result<Vec<&Icon>> {
@@ -202,16 +215,6 @@ impl Runtime {
         })
     }
 
-    pub fn prompt_yes_or_no(&self, msg: &str, help: Option<&str>) -> error::Result<YesOrNo> {
-        match inquire::CustomType::<YesOrNo>::new(msg)
-            .with_help_message(help.unwrap_or("Yes/No/All yes, <Ctrl-C> to abort"))
-            .prompt()
-        {
-            Err(InquireError::OperationInterrupted) => error::Interrupted.fail(),
-            t => t.context(error::Prompt),
-        }
-    }
-
     fn autocompleter(&self, candidates: usize) -> Autocompleter {
         Autocompleter {
             icons: self.icons.clone(),
@@ -292,10 +295,11 @@ impl RuntimeBuilder {
 }
 
 pub struct CheckerContext {
-    files: SimpleFiles<String, String>,
-    writer: StandardStream,
-    config: term::Config,
-    history: HashMap<char, char>,
+    pub files: SimpleFiles<String, String>,
+    pub writer: StandardStream,
+    pub config: term::Config,
+    pub history: HashMap<char, char>,
+    pub replace: Vec<Replace>,
 }
 
 impl Default for CheckerContext {
@@ -305,36 +309,7 @@ impl Default for CheckerContext {
             writer: StandardStream::stderr(term::termcolor::ColorChoice::Always),
             config: term::Config::default(),
             history: HashMap::default(),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub enum YesOrNo {
-    Yes,
-    No,
-    AllYes,
-}
-
-impl fmt::Display for YesOrNo {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            YesOrNo::Yes => write!(f, "yes"),
-            YesOrNo::No => write!(f, "no"),
-            YesOrNo::AllYes => write!(f, "all yes"),
-        }
-    }
-}
-
-impl FromStr for YesOrNo {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "y" | "yes" => Ok(Self::Yes),
-            "n" | "no" => Ok(Self::No),
-            "a" | "all" => Ok(Self::AllYes),
-            _ => Err("invalid input"),
+            replace: Vec::default(),
         }
     }
 }

--- a/tests/test-data.txt
+++ b/tests/test-data.txt
@@ -4,6 +4,10 @@ nf-md-folder_multiple  = "󰉓"
 nf-mdi-file_document_box = ""
 nf-md-file_document      = "󰈙"
 
+# Test autofix from histroy
+nf-mdi-file_document_box = ""
+nf-md-file_document      = "󰈙"
+
 nf-mdi-git = "",
 nf-md-git  = "󰊢"
 


### PR DESCRIPTION
This PR adds a new option `--replace` for `fix` sub command to perform automatic patching. See readme for more details.