### PR TITLE
feat(cli): structured output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -236,7 +236,7 @@ dependencies = [
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -295,6 +295,12 @@ checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "lazy_static"
@@ -391,6 +397,8 @@ dependencies = [
  "ngrammatic",
  "once_cell",
  "select",
+ "serde",
+ "serde_json",
  "thisctx",
  "thiserror",
  "tracing",
@@ -534,7 +542,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -551,18 +559,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -621,6 +629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,9 +653,34 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.155"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f2b4817415c6d4210bfe1c7bfcf4801b2d904cb4d0e1a8fdb651013c9e86b8"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.11",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -738,6 +777,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tendril"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,7 +824,7 @@ checksum = "b1d51cadde49cafda283522faf31bc5527b347ced62704e44cf0d24e3f816aa2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -794,7 +844,7 @@ checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -827,7 +877,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,15 @@ itertools = "0.10"
 ngrammatic = "0.4"
 once_cell = "1.17"
 select = "0.6"
+serde_json = "1.0"
 thisctx = "0.4"
 thiserror = "1.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
+
+[dependencies.serde]
+version = "1.0"
+features = ["derive"]
 
 [dependencies.clap]
 version = "4.1"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ warning: Found obsolete icon U+F752
         ...
 ```
 
+### Interactive patching
+
 The output of `fix` command is similar to `check` and shows a prompt asking the
 user to input a new icon to replace the obsolete one.
 
@@ -90,6 +92,8 @@ The prompt accepts several types of input:
 | Icon name         | `nf-md-file_document` |
 | Icon character    | `󰈙`                   |
 
+### Fuzzy autocompletion/search
+
 The prompt also provides fuzzy matched suggestions when typing the icon name:
 
 ```text
@@ -105,12 +109,26 @@ search.
 
 ### Autofix
 
-`nerdfix` provides some features to autofix obsolete icons:
+`nerdfix` provides some features to automatically patch obsolete icons:
 
 - The last input is picked if an icon appears twice.
-- Use `--replace FROM,TO` to replace the prefix of an icon name with another,
-  e.g. `nf-mdi-tab` is replaced by `nf-md-tab` when `--replace nf-mdi-,nf-md-`
-  is specified.
+- Use `fix --replace FROM,TO` to replace the prefix of an icon name with
+  another, e.g. `nf-mdi-tab` is replaced by `nf-md-tab` when
+  `--replace nf-mdi-,nf-md-` is specified.
+
+### Structured output
+
+You can use `check --format json` to get structured output for further use.
+`nerdfix` prints diagnostics with the following fields line by line:
+
+| Field       | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `severity`  | Severity of a diagnostic                                |
+| `path`      | Source file of a diagnostic                             |
+| `type`      | Diagnostic type, currently only `obsolete` is supported |
+| `span`      | Byte index span of an obsolete icon                     |
+| `name`      | Icon name                                               |
+| `codepoint` | Icon codepoint                                          |
 
 ## ⚖️ License
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use std::{path::PathBuf, str::FromStr};
 use thisctx::IntoError;
 
 const V_PATH: &str = "PATH";
-const V_REPLACE: &str = "CLASSES";
+const V_CLASSES: &str = "CLASSES";
 
 #[derive(Debug, Parser)]
 pub struct Cli {
@@ -45,7 +45,7 @@ pub enum Command {
         ///
         /// For example, use `--replace nf-mdi-,nf-md-` to replace all `nf-mdi*` icons
         /// with the same icons in `nf-md*`.
-        #[arg(short, long, value_name(V_REPLACE))]
+        #[arg(long, value_name(V_CLASSES))]
         replace: Vec<Replace>,
     },
     /// Fuzzy search for an icon.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,12 +1,13 @@
 //! Command line arguments parser.
 
 use crate::error;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::{path::PathBuf, str::FromStr};
 use thisctx::IntoError;
 
 const V_PATH: &str = "PATH";
 const V_CLASSES: &str = "CLASSES";
+const V_FORMAT: &str = "FORMAT";
 
 #[derive(Debug, Parser)]
 pub struct Cli {
@@ -29,6 +30,9 @@ pub enum Command {
     },
     /// Check for obsolete icons.
     Check {
+        /// Output format of diagnostics.
+        #[arg(long, value_name(V_FORMAT), default_value("console"))]
+        format: OutputFormat,
         /// Path(s) of files to check.
         #[arg(value_name(V_PATH))]
         source: Vec<PathBuf>,
@@ -81,7 +85,7 @@ impl FromStr for UserInput {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct Replace {
     pub from: String,
     pub to: String,
@@ -99,4 +103,13 @@ impl FromStr for Replace {
             to: to.to_owned(),
         })
     }
+}
+
+#[derive(Clone, Debug, Default, ValueEnum)]
+pub enum OutputFormat {
+    #[value(help("Json output format"))]
+    Json,
+    #[default]
+    #[value(help("Human-readable output format"))]
+    Console,
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -16,7 +16,11 @@ use inquire::InquireError;
 use ngrammatic::{Corpus, CorpusBuilder};
 use once_cell::unsync::OnceCell;
 use serde::Serialize;
-use std::{collections::HashMap, path::Path, rc::Rc};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 use thisctx::{IntoError, WithContext};
 use tracing::warn;
 
@@ -86,6 +90,7 @@ impl Runtime {
                         OutputFormat::Json => {
                             let diag = DiagOutput {
                                 severity: Severity::Info,
+                                path: path.to_owned(),
                                 ty: DiagType::Obsolete {
                                     span: (start, end),
                                     name: icon.name.clone(),
@@ -344,6 +349,7 @@ impl Default for CheckerContext {
 #[derive(Debug, Serialize)]
 pub struct DiagOutput {
     pub severity: Severity,
+    pub path: PathBuf,
     #[serde(flatten)]
     pub ty: DiagType,
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
-use std::fmt;
+use once_cell::unsync::OnceCell;
+use std::{cell::Cell, fmt, marker::PhantomData};
 
 #[cfg(test)]
 macro_rules! icon {
@@ -67,5 +68,25 @@ impl<E: std::error::Error> std::error::Error for ErrorWithSource<E> {
 impl From<crate::error::Error> for ErrorWithSource {
     fn from(value: crate::error::Error) -> Self {
         Self(value)
+    }
+}
+
+pub struct TryLazy<T, E, F> {
+    cell: OnceCell<T>,
+    init: Cell<Option<F>>,
+    _marker: PhantomData<E>,
+}
+
+impl<T, E, F: FnOnce() -> Result<T, E>> TryLazy<T, E, F> {
+    pub fn new(f: F) -> Self {
+        Self {
+            cell: OnceCell::default(),
+            init: Cell::new(Some(f)),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn get(&self) -> Result<&T, E> {
+        self.cell.get_or_try_init(|| self.init.take().unwrap()())
     }
 }


### PR DESCRIPTION
This PR adds a new option `check --format` which allows you get structured diagnostics. See readme for further information.