### PR TITLE
refactor: error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +123,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +174,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaff6f8ce506b9773fa786672d63fc7a191ffea1be33f72bbd4aeacefca9ffc8"
 
 [[package]]
 name = "cfg-if"
@@ -283,6 +328,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "extend"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +365,12 @@ checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "hashbrown"
@@ -368,6 +429,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_debug"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +500,46 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miette"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.70",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -451,6 +564,7 @@ dependencies = [
  "indexmap",
  "inquire",
  "itertools",
+ "miette",
  "noodler",
  "nu-ansi-term 0.50.0",
  "once_cell",
@@ -517,6 +631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +650,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "parking_lot"
@@ -647,6 +776,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +903,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "strip-ansi-escapes"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +922,27 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "supports-color"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9829b314621dfc575df4e409e79f9d6a66a3bd707ab73f23cb4aa3a854ac854f"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0a1e5168041f5f3ff68ff7d95dcb9c8749df29f6e7e89ada40dd4c9de404ee"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
@@ -801,10 +976,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thisctx"
@@ -951,6 +1147,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +569,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "codespan-reporting",
+ "content_inspector",
  "extend",
  "indexmap",
  "inquire",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 clap = { version = ">=4.0, <4.5", features = ["derive"] }
 codespan-reporting = "0.11.1"
+content_inspector = "0.2.4"
 extend = "1.2"
 indexmap = "2.2"
 inquire = "0.7.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ extend = "1.2"
 indexmap = "2.2"
 inquire = "0.7.5"
 itertools = "0.13.0"
+miette = { version = "7.2", features = ["fancy"] }
 noodler = "0.1.0"
 nu-ansi-term = "0.50.0"
 once_cell = "1.19"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,8 @@
 //! Command line arguments parser.
 
-use core::fmt;
-use std::io;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::{fmt, io};
 
 use clap::{Parser, Subcommand, ValueEnum};
 use shadow_rs::formatcp;

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,12 +26,6 @@ pub enum Error {
         #[source]
         serde_json::Error,
     ),
-    #[error("Failed when reporting diagnostics")]
-    Reporter(
-        #[from]
-        #[source]
-        codespan_reporting::files::Error,
-    ),
     #[error("Failed when prompting")]
     Prompt(
         #[from]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,11 @@
+use std::fmt;
+
+use miette::{Diagnostic, LabeledSpan};
 use thisctx::WithContext;
 use thiserror::Error;
+
+use crate::icon::Icon;
+use crate::runtime::Severity;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -40,4 +46,57 @@ pub enum Error {
     Interrupted,
     #[error(transparent)]
     Any(Box<dyn Send + Sync + std::error::Error>),
+}
+
+#[derive(Debug, Error)]
+pub(crate) struct ObsoleteIcon<'a> {
+    pub source_code: &'a str,
+    pub icon: &'a Icon,
+    pub span: (usize, usize),
+    pub candidates: &'a [&'a Icon],
+}
+
+impl fmt::Display for ObsoleteIcon<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Found obsolete icon U+{:X}", self.icon.codepoint as u32)
+    }
+}
+
+impl Diagnostic for ObsoleteIcon<'_> {
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.source_code)
+    }
+
+    fn severity(&self) -> Option<miette::Severity> {
+        Some(Severity::Info.into())
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        Some(Box::new(std::iter::once(LabeledSpan::at(
+            self.span.0..self.span.1,
+            format!("Icon '{}' is marked as obsolete", self.icon.name),
+        ))))
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
+        struct DiagnosticNotes<'a>(&'a [&'a Icon]);
+        impl fmt::Display for DiagnosticNotes<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                writeln!(f, "You could replace it with:")?;
+                for (i, &candi) in self.0.iter().enumerate() {
+                    let i = i + 1;
+                    write!(
+                        f,
+                        "  {}. {} U+{:05X} {}",
+                        i, candi.codepoint, candi.codepoint as u32, &candi.name
+                    )?;
+                    if i < self.0.len() {
+                        f.write_str("\n")?;
+                    }
+                }
+                Ok(())
+            }
+        }
+        Some(Box::new(DiagnosticNotes(self.candidates)))
+    }
 }

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -133,7 +133,7 @@ mod substitution {
                 }
             }
             let to = &s[start..];
-            tryb!({
+            tri!({
                 let from = from?;
                 if from.is_empty() || to.is_empty() {
                     None

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,11 +107,13 @@ fn main_impl() -> error::Result<()> {
             format,
             source,
             recursive,
+            include_binary,
         } => {
             let rt = rt.build();
             let mut context = CheckerContext {
                 format,
                 writer: Box::new(std::io::stdout()),
+                include_binary,
                 ..Default::default()
             };
             for source in walk(source.into_iter().map(|p| Source(p, None)), recursive) {
@@ -128,6 +130,7 @@ fn main_impl() -> error::Result<()> {
             write,
             select_first,
             recursive,
+            include_binary,
             source,
         } => {
             if yes {
@@ -137,6 +140,7 @@ fn main_impl() -> error::Result<()> {
             let mut context = CheckerContext {
                 write,
                 select_first,
+                include_binary,
                 ..Default::default()
             };
             let mut buffer = String::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn walk<'a>(
                     .flat_map(|w| w.into_iter())
                 })
                 .filter_map(|entry| {
-                    tryb!({
+                    tri!({
                         let path = entry?.into_path();
                         if path.is_file() {
                             Ok(Some(path))
@@ -116,7 +116,7 @@ fn main_impl() -> error::Result<()> {
                 ..Default::default()
             };
             for source in walk(source.into_iter().map(|p| Source(p, None)), recursive) {
-                tryb!({
+                tri!({
                     let source = source?;
                     rt.check(&mut context, &source.0, None)
                 })
@@ -142,7 +142,7 @@ fn main_impl() -> error::Result<()> {
             };
             let mut buffer = String::new();
             for source in walk(source, recursive) {
-                tryb!({
+                tri!({
                     let source = source?;
                     let Source(input, output) = &source;
                     let output = output.as_ref().unwrap_or(input);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,13 +12,12 @@ shadow_rs::shadow!(shadow);
 
 use clap::Parser;
 use cli::{Command, IoPath, Source};
-use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 use prompt::YesOrNo;
 use runtime::{CheckerContext, Runtime};
 use thisctx::WithContext;
 use tracing::{error, info, warn, Level};
 use tracing_subscriber::prelude::*;
-use util::{LogStatus, ResultExt};
+use util::{LogStatus, ResultExt as _};
 use walkdir::WalkDir;
 
 static ICONS: &str = include_str!("./icons.json");
@@ -112,7 +111,7 @@ fn main_impl() -> error::Result<()> {
             let rt = rt.build();
             let mut context = CheckerContext {
                 format,
-                writer: StandardStream::stdout(ColorChoice::Always),
+                writer: Box::new(std::io::stdout()),
                 ..Default::default()
             };
             for source in walk(source.into_iter().map(|p| Source(p, None)), recursive) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -67,7 +67,7 @@ macro_rules! msginfo {
     };
 }
 
-macro_rules! tryb {
+macro_rules! tri {
     ($block:block) => {
         (|| $block)()
     };

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,9 +2,9 @@
 #![cfg(unix)]
 
 use core::fmt;
-use std::env;
 use std::path::Path;
 use std::process::{Command, Output};
+use std::{env, fs};
 
 use assert_cmd::assert::Assert;
 use assert_cmd::prelude::*;
@@ -74,11 +74,11 @@ fn cmp_or_override(file: &str) -> impl '_ + Predicate<[u8]> {
     let path = Path::new("tests").join(file);
     if matches!(env::var("NERDFIX_TEST").as_deref(), Ok("overwrite")) {
         BoxedPredicate::new(predicate::function(move |expected: &[u8]| {
-            std::fs::write(&path, expected).unwrap();
+            fs::write(&path, expected).unwrap();
             true
         }))
     } else {
-        let expected = std::fs::read_to_string(path).unwrap();
+        let expected = fs::read_to_string(path).unwrap();
         BoxedPredicate::new(predicate::str::diff(expected).from_utf8())
     }
 }

--- a/tests/cli/check.stdout
+++ b/tests/cli/check.stdout
@@ -1,79 +1,92 @@
-note: Found obsolete icon U+F752
-  ┌─ tests/test-data.txt:1:24
-  │
-1 │ mdi-folder_multiple = ""
-  │                        ^ Icon 'mdi-folder_multiple' is marked as obsolete
-  │
-  = You could replace it with:
-        1. 󰉓 U+F0253 md-folder_multiple
-        2. 󱏓 U+F13D3 md-folder_star_multiple
-        3. 󰉔 U+F0254 md-folder_multiple_image
-        4. 󱑾 U+F147E md-folder_multiple_plus
+  ☞ Found obsolete icon U+F752
+   ╭─[1:24]
+ 1 │ mdi-folder_multiple = ""
+   ·                        ┬
+   ·                        ╰── Icon 'mdi-folder_multiple' is marked as obsolete
+ 2 │ md-folder_multiple  = "󰉓"
+   ╰────
+  help: You could replace it with:
+          1. 󰉓 U+F0253 md-folder_multiple
+          2. 󱏓 U+F13D3 md-folder_star_multiple
+          3. 󰉔 U+F0254 md-folder_multiple_image
+          4. 󱑾 U+F147E md-folder_multiple_plus
 
-note: Found obsolete icon U+F719
-  ┌─ tests/test-data.txt:4:26
-  │
-4 │ mdi-file_document_box = ""
-  │                          ^ Icon 'mdi-file_document_box' is marked as obsolete
-  │
-  = You could replace it with:
-        1. 󰈙 U+F0219 md-file_document
-        2. 󰷈 U+F0DC8 md-file_document_edit
-        3. 󱪝 U+F1A9D md-file_document_plus
-        4. 󱪗 U+F1A97 md-file_document_alert
+  ☞ Found obsolete icon U+F719
+   ╭─[4:26]
+ 3 │ 
+ 4 │ mdi-file_document_box = ""
+   ·                          ┬
+   ·                          ╰── Icon 'mdi-file_document_box' is marked as obsolete
+ 5 │ md-file_document      = "󰈙"
+   ╰────
+  help: You could replace it with:
+          1. 󰈙 U+F0219 md-file_document
+          2. 󰷈 U+F0DC8 md-file_document_edit
+          3. 󱪝 U+F1A9D md-file_document_plus
+          4. 󱪗 U+F1A97 md-file_document_alert
 
-note: Found obsolete icon U+F719
-  ┌─ tests/test-data.txt:8:26
-  │
-8 │ mdi-file_document_box = ""
-  │                          ^ Icon 'mdi-file_document_box' is marked as obsolete
-  │
-  = You could replace it with:
-        1. 󰈙 U+F0219 md-file_document
-        2. 󰷈 U+F0DC8 md-file_document_edit
-        3. 󱪝 U+F1A9D md-file_document_plus
-        4. 󱪗 U+F1A97 md-file_document_alert
+  ☞ Found obsolete icon U+F719
+   ╭─[8:26]
+ 7 │ # Test autofix from histroy
+ 8 │ mdi-file_document_box = ""
+   ·                          ┬
+   ·                          ╰── Icon 'mdi-file_document_box' is marked as obsolete
+ 9 │ md-file_document      = "󰈙"
+   ╰────
+  help: You could replace it with:
+          1. 󰈙 U+F0219 md-file_document
+          2. 󰷈 U+F0DC8 md-file_document_edit
+          3. 󱪝 U+F1A9D md-file_document_plus
+          4. 󱪗 U+F1A97 md-file_document_alert
 
-note: Found obsolete icon U+F7A1
-   ┌─ tests/test-data.txt:11:12
-   │
-11 │ mdi-git = "",
-   │            ^ Icon 'mdi-git' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰊢 U+F02A2 md-git
-         2.  U+0E65D seti-git
+  ☞ Found obsolete icon U+F7A1
+    ╭─[11:12]
+ 10 │ 
+ 11 │ mdi-git = "",
+    ·            ┬
+    ·            ╰── Icon 'mdi-git' is marked as obsolete
+ 12 │ md-git  = "󰊢"
+    ╰────
+  help: You could replace it with:
+          1. 󰊢 U+F02A2 md-git
+          2.  U+0E65D seti-git
 
-note: Found obsolete icon U+F9E8
-   ┌─ tests/test-data.txt:14:12
-   │
-14 │ mdi-tab = "裡"
-   │            ^^ Icon 'mdi-tab' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰓩 U+F04E9 md-tab
+  ☞ Found obsolete icon U+F9E8
+    ╭─[14:12]
+ 13 │ 
+ 14 │ mdi-tab = "裡"
+    ·            ─┬
+    ·             ╰── Icon 'mdi-tab' is marked as obsolete
+ 15 │ md-tab  = "󰓩"
+    ╰────
+  help: You could replace it with:
+          1. 󰓩 U+F04E9 md-tab
 
-note: Found obsolete icon U+FC0A
-   ┌─ tests/test-data.txt:17:24
-   │
-17 │ mdi-rhombus_outline = "ﰊ"
-   │                        ^ Icon 'mdi-rhombus_outline' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰜌 U+F070C md-rhombus_outline
-         2. 󰮦 U+F0BA6 md-help_rhombus_outline
-         3. 󱇏 U+F11CF md-alert_rhombus_outline
-         4. 󱓝 U+F14DD md-rhombus_split_outline
+  ☞ Found obsolete icon U+FC0A
+    ╭─[17:24]
+ 16 │ 
+ 17 │ mdi-rhombus_outline = "ﰊ"
+    ·                        ┬
+    ·                        ╰── Icon 'mdi-rhombus_outline' is marked as obsolete
+ 18 │ md-rhombus_outline  = "󰜌"
+    ╰────
+  help: You could replace it with:
+          1. 󰜌 U+F070C md-rhombus_outline
+          2. 󰮦 U+F0BA6 md-help_rhombus_outline
+          3. 󱇏 U+F11CF md-alert_rhombus_outline
+          4. 󱓝 U+F14DD md-rhombus_split_outline
 
-note: Found obsolete icon U+F554
-   ┌─ tests/test-data.txt:20:26
-   │
-20 │ mdi-arrow_right_thick = ""
-   │                          ^ Icon 'mdi-arrow_right_thick' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰁕 U+F0055 md-arrow_right_thick
-         2. 󰧆 U+F09C6 md-arrow_top_right_thick
-         3. 󰦺 U+F09BA md-arrow_bottom_right_thick
-         4. 󱦰 U+F19B0 md-arrow_right_thin
+  ☞ Found obsolete icon U+F554
+    ╭─[20:26]
+ 19 │ 
+ 20 │ mdi-arrow_right_thick = ""
+    ·                          ┬
+    ·                          ╰── Icon 'mdi-arrow_right_thick' is marked as obsolete
+ 21 │ md-arrow_right_thick  = "󰁕"
+    ╰────
+  help: You could replace it with:
+          1. 󰁕 U+F0055 md-arrow_right_thick
+          2. 󰧆 U+F09C6 md-arrow_top_right_thick
+          3. 󰦺 U+F09BA md-arrow_bottom_right_thick
+          4. 󱦰 U+F19B0 md-arrow_right_thin
 

--- a/tests/cli/check_with_db.stdout
+++ b/tests/cli/check_with_db.stdout
@@ -1,18 +1,22 @@
-note: Found obsolete icon U+F719
-  ┌─ tests/test-data.txt:4:26
-  │
-4 │ mdi-file_document_box = ""
-  │                          ^ Icon 'mdi-file_document_box' is marked as obsolete
-  │
-  = You could replace it with:
-        1. 󰈙 U+F0219 md-file_document
+  ☞ Found obsolete icon U+F719
+   ╭─[4:26]
+ 3 │ 
+ 4 │ mdi-file_document_box = ""
+   ·                          ┬
+   ·                          ╰── Icon 'mdi-file_document_box' is marked as obsolete
+ 5 │ md-file_document      = "󰈙"
+   ╰────
+  help: You could replace it with:
+          1. 󰈙 U+F0219 md-file_document
 
-note: Found obsolete icon U+F719
-  ┌─ tests/test-data.txt:8:26
-  │
-8 │ mdi-file_document_box = ""
-  │                          ^ Icon 'mdi-file_document_box' is marked as obsolete
-  │
-  = You could replace it with:
-        1. 󰈙 U+F0219 md-file_document
+  ☞ Found obsolete icon U+F719
+   ╭─[8:26]
+ 7 │ # Test autofix from histroy
+ 8 │ mdi-file_document_box = ""
+   ·                          ┬
+   ·                          ╰── Icon 'mdi-file_document_box' is marked as obsolete
+ 9 │ md-file_document      = "󰈙"
+   ╰────
+  help: You could replace it with:
+          1. 󰈙 U+F0219 md-file_document
 

--- a/tests/cli/fix.stderr
+++ b/tests/cli/fix.stderr
@@ -1,88 +1,101 @@
  INFO Check input file from 'tests/test-data.txt'
-note: Found obsolete icon U+F752
-  ┌─ tests/test-data.txt:1:24
-  │
-1 │ mdi-folder_multiple = ""
-  │                        ^ Icon 'mdi-folder_multiple' is marked as obsolete
-  │
-  = You could replace it with:
-        1. 󰉓 U+F0253 md-folder_multiple
-        2. 󱏓 U+F13D3 md-folder_star_multiple
-        3. 󰉔 U+F0254 md-folder_multiple_image
-        4. 󱑾 U+F147E md-folder_multiple_plus
+  ☞ Found obsolete icon U+F752
+   ╭─[1:24]
+ 1 │ mdi-folder_multiple = ""
+   ·                        ┬
+   ·                        ╰── Icon 'mdi-folder_multiple' is marked as obsolete
+ 2 │ md-folder_multiple  = "󰉓"
+   ╰────
+  help: You could replace it with:
+          1. 󰉓 U+F0253 md-folder_multiple
+          2. 󱏓 U+F13D3 md-folder_star_multiple
+          3. 󰉔 U+F0254 md-folder_multiple_image
+          4. 󱑾 U+F147E md-folder_multiple_plus
 
 # Autofix with substitution '󰉓'
-note: Found obsolete icon U+F719
-  ┌─ tests/test-data.txt:4:26
-  │
-4 │ mdi-file_document_box = ""
-  │                          ^ Icon 'mdi-file_document_box' is marked as obsolete
-  │
-  = You could replace it with:
-        1. 󰈙 U+F0219 md-file_document
-        2. 󰷈 U+F0DC8 md-file_document_edit
-        3. 󱪝 U+F1A9D md-file_document_plus
-        4. 󱪗 U+F1A97 md-file_document_alert
+  ☞ Found obsolete icon U+F719
+   ╭─[4:26]
+ 3 │ 
+ 4 │ mdi-file_document_box = ""
+   ·                          ┬
+   ·                          ╰── Icon 'mdi-file_document_box' is marked as obsolete
+ 5 │ md-file_document      = "󰈙"
+   ╰────
+  help: You could replace it with:
+          1. 󰈙 U+F0219 md-file_document
+          2. 󰷈 U+F0DC8 md-file_document_edit
+          3. 󱪝 U+F1A9D md-file_document_plus
+          4. 󱪗 U+F1A97 md-file_document_alert
 
 # Autofix with the first suggestion '󰈙'
-note: Found obsolete icon U+F719
-  ┌─ tests/test-data.txt:8:26
-  │
-8 │ mdi-file_document_box = ""
-  │                          ^ Icon 'mdi-file_document_box' is marked as obsolete
-  │
-  = You could replace it with:
-        1. 󰈙 U+F0219 md-file_document
-        2. 󰷈 U+F0DC8 md-file_document_edit
-        3. 󱪝 U+F1A9D md-file_document_plus
-        4. 󱪗 U+F1A97 md-file_document_alert
+  ☞ Found obsolete icon U+F719
+   ╭─[8:26]
+ 7 │ # Test autofix from histroy
+ 8 │ mdi-file_document_box = ""
+   ·                          ┬
+   ·                          ╰── Icon 'mdi-file_document_box' is marked as obsolete
+ 9 │ md-file_document      = "󰈙"
+   ╰────
+  help: You could replace it with:
+          1. 󰈙 U+F0219 md-file_document
+          2. 󰷈 U+F0DC8 md-file_document_edit
+          3. 󱪝 U+F1A9D md-file_document_plus
+          4. 󱪗 U+F1A97 md-file_document_alert
 
 # Autofix with the first suggestion '󰈙'
-note: Found obsolete icon U+F7A1
-   ┌─ tests/test-data.txt:11:12
-   │
-11 │ mdi-git = "",
-   │            ^ Icon 'mdi-git' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰊢 U+F02A2 md-git
-         2.  U+0E65D seti-git
+  ☞ Found obsolete icon U+F7A1
+    ╭─[11:12]
+ 10 │ 
+ 11 │ mdi-git = "",
+    ·            ┬
+    ·            ╰── Icon 'mdi-git' is marked as obsolete
+ 12 │ md-git  = "󰊢"
+    ╰────
+  help: You could replace it with:
+          1. 󰊢 U+F02A2 md-git
+          2.  U+0E65D seti-git
 
 # Autofix with substitution '󰊢'
-note: Found obsolete icon U+F9E8
-   ┌─ tests/test-data.txt:14:12
-   │
-14 │ mdi-tab = "裡"
-   │            ^^ Icon 'mdi-tab' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰓩 U+F04E9 md-tab
+  ☞ Found obsolete icon U+F9E8
+    ╭─[14:12]
+ 13 │ 
+ 14 │ mdi-tab = "裡"
+    ·            ─┬
+    ·             ╰── Icon 'mdi-tab' is marked as obsolete
+ 15 │ md-tab  = "󰓩"
+    ╰────
+  help: You could replace it with:
+          1. 󰓩 U+F04E9 md-tab
 
 # Autofix with substitution '󰓩'
-note: Found obsolete icon U+FC0A
-   ┌─ tests/test-data.txt:17:24
-   │
-17 │ mdi-rhombus_outline = "ﰊ"
-   │                        ^ Icon 'mdi-rhombus_outline' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰜌 U+F070C md-rhombus_outline
-         2. 󰮦 U+F0BA6 md-help_rhombus_outline
-         3. 󱇏 U+F11CF md-alert_rhombus_outline
-         4. 󱓝 U+F14DD md-rhombus_split_outline
+  ☞ Found obsolete icon U+FC0A
+    ╭─[17:24]
+ 16 │ 
+ 17 │ mdi-rhombus_outline = "ﰊ"
+    ·                        ┬
+    ·                        ╰── Icon 'mdi-rhombus_outline' is marked as obsolete
+ 18 │ md-rhombus_outline  = "󰜌"
+    ╰────
+  help: You could replace it with:
+          1. 󰜌 U+F070C md-rhombus_outline
+          2. 󰮦 U+F0BA6 md-help_rhombus_outline
+          3. 󱇏 U+F11CF md-alert_rhombus_outline
+          4. 󱓝 U+F14DD md-rhombus_split_outline
 
 # Autofix with substitution '󰜌'
-note: Found obsolete icon U+F554
-   ┌─ tests/test-data.txt:20:26
-   │
-20 │ mdi-arrow_right_thick = ""
-   │                          ^ Icon 'mdi-arrow_right_thick' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰁕 U+F0055 md-arrow_right_thick
-         2. 󰧆 U+F09C6 md-arrow_top_right_thick
-         3. 󰦺 U+F09BA md-arrow_bottom_right_thick
-         4. 󱦰 U+F19B0 md-arrow_right_thin
+  ☞ Found obsolete icon U+F554
+    ╭─[20:26]
+ 19 │ 
+ 20 │ mdi-arrow_right_thick = ""
+    ·                          ┬
+    ·                          ╰── Icon 'mdi-arrow_right_thick' is marked as obsolete
+ 21 │ md-arrow_right_thick  = "󰁕"
+    ╰────
+  help: You could replace it with:
+          1. 󰁕 U+F0055 md-arrow_right_thick
+          2. 󰧆 U+F09C6 md-arrow_top_right_thick
+          3. 󰦺 U+F09BA md-arrow_bottom_right_thick
+          4. 󱦰 U+F19B0 md-arrow_right_thin
 
 # Autofix with substitution '󰁕'
  INFO Write output to 'STDIO'

--- a/tests/cli/fix_with_exact_subs.stderr
+++ b/tests/cli/fix_with_exact_subs.stderr
@@ -1,90 +1,103 @@
  INFO Load input from 'src/icons.json'
  INFO Load input from 'tests/test-substitutions.json'
  INFO Check input file from 'tests/test-data.txt'
-note: Found obsolete icon U+F752
-  ┌─ tests/test-data.txt:1:24
-  │
-1 │ mdi-folder_multiple = ""
-  │                        ^ Icon 'mdi-folder_multiple' is marked as obsolete
-  │
-  = You could replace it with:
-        1. 󰉓 U+F0253 md-folder_multiple
-        2. 󱏓 U+F13D3 md-folder_star_multiple
-        3. 󰉔 U+F0254 md-folder_multiple_image
-        4. 󱑾 U+F147E md-folder_multiple_plus
+  ☞ Found obsolete icon U+F752
+   ╭─[1:24]
+ 1 │ mdi-folder_multiple = ""
+   ·                        ┬
+   ·                        ╰── Icon 'mdi-folder_multiple' is marked as obsolete
+ 2 │ md-folder_multiple  = "󰉓"
+   ╰────
+  help: You could replace it with:
+          1. 󰉓 U+F0253 md-folder_multiple
+          2. 󱏓 U+F13D3 md-folder_star_multiple
+          3. 󰉔 U+F0254 md-folder_multiple_image
+          4. 󱑾 U+F147E md-folder_multiple_plus
 
 # Autofix with the first suggestion '󰉓'
-note: Found obsolete icon U+F719
-  ┌─ tests/test-data.txt:4:26
-  │
-4 │ mdi-file_document_box = ""
-  │                          ^ Icon 'mdi-file_document_box' is marked as obsolete
-  │
-  = You could replace it with:
-        1. 󰈙 U+F0219 md-file_document
-        2. 󰷈 U+F0DC8 md-file_document_edit
-        3. 󱪝 U+F1A9D md-file_document_plus
-        4. 󱪗 U+F1A97 md-file_document_alert
+  ☞ Found obsolete icon U+F719
+   ╭─[4:26]
+ 3 │ 
+ 4 │ mdi-file_document_box = ""
+   ·                          ┬
+   ·                          ╰── Icon 'mdi-file_document_box' is marked as obsolete
+ 5 │ md-file_document      = "󰈙"
+   ╰────
+  help: You could replace it with:
+          1. 󰈙 U+F0219 md-file_document
+          2. 󰷈 U+F0DC8 md-file_document_edit
+          3. 󱪝 U+F1A9D md-file_document_plus
+          4. 󱪗 U+F1A97 md-file_document_alert
 
 # Autofix with substitution '󰈙'
-note: Found obsolete icon U+F719
-  ┌─ tests/test-data.txt:8:26
-  │
-8 │ mdi-file_document_box = ""
-  │                          ^ Icon 'mdi-file_document_box' is marked as obsolete
-  │
-  = You could replace it with:
-        1. 󰈙 U+F0219 md-file_document
-        2. 󰷈 U+F0DC8 md-file_document_edit
-        3. 󱪝 U+F1A9D md-file_document_plus
-        4. 󱪗 U+F1A97 md-file_document_alert
+  ☞ Found obsolete icon U+F719
+   ╭─[8:26]
+ 7 │ # Test autofix from histroy
+ 8 │ mdi-file_document_box = ""
+   ·                          ┬
+   ·                          ╰── Icon 'mdi-file_document_box' is marked as obsolete
+ 9 │ md-file_document      = "󰈙"
+   ╰────
+  help: You could replace it with:
+          1. 󰈙 U+F0219 md-file_document
+          2. 󰷈 U+F0DC8 md-file_document_edit
+          3. 󱪝 U+F1A9D md-file_document_plus
+          4. 󱪗 U+F1A97 md-file_document_alert
 
 # Autofix with substitution '󰈙'
-note: Found obsolete icon U+F7A1
-   ┌─ tests/test-data.txt:11:12
-   │
-11 │ mdi-git = "",
-   │            ^ Icon 'mdi-git' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰊢 U+F02A2 md-git
-         2.  U+0E65D seti-git
+  ☞ Found obsolete icon U+F7A1
+    ╭─[11:12]
+ 10 │ 
+ 11 │ mdi-git = "",
+    ·            ┬
+    ·            ╰── Icon 'mdi-git' is marked as obsolete
+ 12 │ md-git  = "󰊢"
+    ╰────
+  help: You could replace it with:
+          1. 󰊢 U+F02A2 md-git
+          2.  U+0E65D seti-git
 
 # Autofix with the first suggestion '󰊢'
-note: Found obsolete icon U+F9E8
-   ┌─ tests/test-data.txt:14:12
-   │
-14 │ mdi-tab = "裡"
-   │            ^^ Icon 'mdi-tab' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰓩 U+F04E9 md-tab
+  ☞ Found obsolete icon U+F9E8
+    ╭─[14:12]
+ 13 │ 
+ 14 │ mdi-tab = "裡"
+    ·            ─┬
+    ·             ╰── Icon 'mdi-tab' is marked as obsolete
+ 15 │ md-tab  = "󰓩"
+    ╰────
+  help: You could replace it with:
+          1. 󰓩 U+F04E9 md-tab
 
 # Autofix with the first suggestion '󰓩'
-note: Found obsolete icon U+FC0A
-   ┌─ tests/test-data.txt:17:24
-   │
-17 │ mdi-rhombus_outline = "ﰊ"
-   │                        ^ Icon 'mdi-rhombus_outline' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰜌 U+F070C md-rhombus_outline
-         2. 󰮦 U+F0BA6 md-help_rhombus_outline
-         3. 󱇏 U+F11CF md-alert_rhombus_outline
-         4. 󱓝 U+F14DD md-rhombus_split_outline
+  ☞ Found obsolete icon U+FC0A
+    ╭─[17:24]
+ 16 │ 
+ 17 │ mdi-rhombus_outline = "ﰊ"
+    ·                        ┬
+    ·                        ╰── Icon 'mdi-rhombus_outline' is marked as obsolete
+ 18 │ md-rhombus_outline  = "󰜌"
+    ╰────
+  help: You could replace it with:
+          1. 󰜌 U+F070C md-rhombus_outline
+          2. 󰮦 U+F0BA6 md-help_rhombus_outline
+          3. 󱇏 U+F11CF md-alert_rhombus_outline
+          4. 󱓝 U+F14DD md-rhombus_split_outline
 
 # Autofix with the first suggestion '󰜌'
-note: Found obsolete icon U+F554
-   ┌─ tests/test-data.txt:20:26
-   │
-20 │ mdi-arrow_right_thick = ""
-   │                          ^ Icon 'mdi-arrow_right_thick' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰁕 U+F0055 md-arrow_right_thick
-         2. 󰧆 U+F09C6 md-arrow_top_right_thick
-         3. 󰦺 U+F09BA md-arrow_bottom_right_thick
-         4. 󱦰 U+F19B0 md-arrow_right_thin
+  ☞ Found obsolete icon U+F554
+    ╭─[20:26]
+ 19 │ 
+ 20 │ mdi-arrow_right_thick = ""
+    ·                          ┬
+    ·                          ╰── Icon 'mdi-arrow_right_thick' is marked as obsolete
+ 21 │ md-arrow_right_thick  = "󰁕"
+    ╰────
+  help: You could replace it with:
+          1. 󰁕 U+F0055 md-arrow_right_thick
+          2. 󰧆 U+F09C6 md-arrow_top_right_thick
+          3. 󰦺 U+F09BA md-arrow_bottom_right_thick
+          4. 󱦰 U+F19B0 md-arrow_right_thin
 
 # Autofix with the first suggestion '󰁕'
  INFO Write output to 'STDIO'

--- a/tests/cli/fix_with_prefix_subs.stderr
+++ b/tests/cli/fix_with_prefix_subs.stderr
@@ -1,89 +1,102 @@
  INFO Load input from 'src/icons.json'
  INFO Check input file from 'tests/test-data.txt'
-note: Found obsolete icon U+F752
-  ┌─ tests/test-data.txt:1:24
-  │
-1 │ mdi-folder_multiple = ""
-  │                        ^ Icon 'mdi-folder_multiple' is marked as obsolete
-  │
-  = You could replace it with:
-        1. 󰉓 U+F0253 md-folder_multiple
-        2. 󱏓 U+F13D3 md-folder_star_multiple
-        3. 󰉔 U+F0254 md-folder_multiple_image
-        4. 󱑾 U+F147E md-folder_multiple_plus
+  ☞ Found obsolete icon U+F752
+   ╭─[1:24]
+ 1 │ mdi-folder_multiple = ""
+   ·                        ┬
+   ·                        ╰── Icon 'mdi-folder_multiple' is marked as obsolete
+ 2 │ md-folder_multiple  = "󰉓"
+   ╰────
+  help: You could replace it with:
+          1. 󰉓 U+F0253 md-folder_multiple
+          2. 󱏓 U+F13D3 md-folder_star_multiple
+          3. 󰉔 U+F0254 md-folder_multiple_image
+          4. 󱑾 U+F147E md-folder_multiple_plus
 
 # Autofix with substitution '󰉓'
-note: Found obsolete icon U+F719
-  ┌─ tests/test-data.txt:4:26
-  │
-4 │ mdi-file_document_box = ""
-  │                          ^ Icon 'mdi-file_document_box' is marked as obsolete
-  │
-  = You could replace it with:
-        1. 󰈙 U+F0219 md-file_document
-        2. 󰷈 U+F0DC8 md-file_document_edit
-        3. 󱪝 U+F1A9D md-file_document_plus
-        4. 󱪗 U+F1A97 md-file_document_alert
+  ☞ Found obsolete icon U+F719
+   ╭─[4:26]
+ 3 │ 
+ 4 │ mdi-file_document_box = ""
+   ·                          ┬
+   ·                          ╰── Icon 'mdi-file_document_box' is marked as obsolete
+ 5 │ md-file_document      = "󰈙"
+   ╰────
+  help: You could replace it with:
+          1. 󰈙 U+F0219 md-file_document
+          2. 󰷈 U+F0DC8 md-file_document_edit
+          3. 󱪝 U+F1A9D md-file_document_plus
+          4. 󱪗 U+F1A97 md-file_document_alert
 
 # Autofix with the first suggestion '󰈙'
-note: Found obsolete icon U+F719
-  ┌─ tests/test-data.txt:8:26
-  │
-8 │ mdi-file_document_box = ""
-  │                          ^ Icon 'mdi-file_document_box' is marked as obsolete
-  │
-  = You could replace it with:
-        1. 󰈙 U+F0219 md-file_document
-        2. 󰷈 U+F0DC8 md-file_document_edit
-        3. 󱪝 U+F1A9D md-file_document_plus
-        4. 󱪗 U+F1A97 md-file_document_alert
+  ☞ Found obsolete icon U+F719
+   ╭─[8:26]
+ 7 │ # Test autofix from histroy
+ 8 │ mdi-file_document_box = ""
+   ·                          ┬
+   ·                          ╰── Icon 'mdi-file_document_box' is marked as obsolete
+ 9 │ md-file_document      = "󰈙"
+   ╰────
+  help: You could replace it with:
+          1. 󰈙 U+F0219 md-file_document
+          2. 󰷈 U+F0DC8 md-file_document_edit
+          3. 󱪝 U+F1A9D md-file_document_plus
+          4. 󱪗 U+F1A97 md-file_document_alert
 
 # Autofix with the first suggestion '󰈙'
-note: Found obsolete icon U+F7A1
-   ┌─ tests/test-data.txt:11:12
-   │
-11 │ mdi-git = "",
-   │            ^ Icon 'mdi-git' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰊢 U+F02A2 md-git
-         2.  U+0E65D seti-git
+  ☞ Found obsolete icon U+F7A1
+    ╭─[11:12]
+ 10 │ 
+ 11 │ mdi-git = "",
+    ·            ┬
+    ·            ╰── Icon 'mdi-git' is marked as obsolete
+ 12 │ md-git  = "󰊢"
+    ╰────
+  help: You could replace it with:
+          1. 󰊢 U+F02A2 md-git
+          2.  U+0E65D seti-git
 
 # Autofix with substitution '󰊢'
-note: Found obsolete icon U+F9E8
-   ┌─ tests/test-data.txt:14:12
-   │
-14 │ mdi-tab = "裡"
-   │            ^^ Icon 'mdi-tab' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰓩 U+F04E9 md-tab
+  ☞ Found obsolete icon U+F9E8
+    ╭─[14:12]
+ 13 │ 
+ 14 │ mdi-tab = "裡"
+    ·            ─┬
+    ·             ╰── Icon 'mdi-tab' is marked as obsolete
+ 15 │ md-tab  = "󰓩"
+    ╰────
+  help: You could replace it with:
+          1. 󰓩 U+F04E9 md-tab
 
 # Autofix with substitution '󰓩'
-note: Found obsolete icon U+FC0A
-   ┌─ tests/test-data.txt:17:24
-   │
-17 │ mdi-rhombus_outline = "ﰊ"
-   │                        ^ Icon 'mdi-rhombus_outline' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰜌 U+F070C md-rhombus_outline
-         2. 󰮦 U+F0BA6 md-help_rhombus_outline
-         3. 󱇏 U+F11CF md-alert_rhombus_outline
-         4. 󱓝 U+F14DD md-rhombus_split_outline
+  ☞ Found obsolete icon U+FC0A
+    ╭─[17:24]
+ 16 │ 
+ 17 │ mdi-rhombus_outline = "ﰊ"
+    ·                        ┬
+    ·                        ╰── Icon 'mdi-rhombus_outline' is marked as obsolete
+ 18 │ md-rhombus_outline  = "󰜌"
+    ╰────
+  help: You could replace it with:
+          1. 󰜌 U+F070C md-rhombus_outline
+          2. 󰮦 U+F0BA6 md-help_rhombus_outline
+          3. 󱇏 U+F11CF md-alert_rhombus_outline
+          4. 󱓝 U+F14DD md-rhombus_split_outline
 
 # Autofix with substitution '󰜌'
-note: Found obsolete icon U+F554
-   ┌─ tests/test-data.txt:20:26
-   │
-20 │ mdi-arrow_right_thick = ""
-   │                          ^ Icon 'mdi-arrow_right_thick' is marked as obsolete
-   │
-   = You could replace it with:
-         1. 󰁕 U+F0055 md-arrow_right_thick
-         2. 󰧆 U+F09C6 md-arrow_top_right_thick
-         3. 󰦺 U+F09BA md-arrow_bottom_right_thick
-         4. 󱦰 U+F19B0 md-arrow_right_thin
+  ☞ Found obsolete icon U+F554
+    ╭─[20:26]
+ 19 │ 
+ 20 │ mdi-arrow_right_thick = ""
+    ·                          ┬
+    ·                          ╰── Icon 'mdi-arrow_right_thick' is marked as obsolete
+ 21 │ md-arrow_right_thick  = "󰁕"
+    ╰────
+  help: You could replace it with:
+          1. 󰁕 U+F0055 md-arrow_right_thick
+          2. 󰧆 U+F09C6 md-arrow_top_right_thick
+          3. 󰦺 U+F09BA md-arrow_bottom_right_thick
+          4. 󱦰 U+F19B0 md-arrow_right_thin
 
 # Autofix with substitution '󰁕'
  INFO Write output to 'STDIO'


### PR DESCRIPTION
Use [miette](https://docs.rs/miette/latest/miette) to report diagnostics, as [codespan_reporting](https://docs.rs/codespan-reporting/latest/codespan_reporting/index.html) has not been actively maintained for a while. This should also fix #18: Currently, all checked files are persisted in the memory (check [here](https://github.com/loichyan/nerdfix/blob/e90e787a40f853916f479062676e293f197d647a/src/runtime.rs#L125)), leading to memory leaks.

This PR also introduces binary files filtering, which significantly reduces "Invalid UTF-8" errors.