### PR TITLE
fix(cli): report the source path of diagnostics

### DIFF
--- a/tests/cli/check.stderr
+++ b/tests/cli/check.stderr
@@ -1,1 +1,1 @@
- INFO Check input file from 'tests/test-data.txt'
+ INFO Check input from 'tests/test-data.txt'

--- a/tests/cli/check.stdout
+++ b/tests/cli/check.stdout
@@ -1,5 +1,5 @@
   ☞ Found obsolete icon U+F752
-   ╭─[1:24]
+   ╭─[tests/test-data.txt:1:24]
  1 │ mdi-folder_multiple = ""
    ·                        ┬
    ·                        ╰── Icon 'mdi-folder_multiple' is marked as obsolete
@@ -12,7 +12,7 @@
           4. 󱑾 U+F147E md-folder_multiple_plus
 
   ☞ Found obsolete icon U+F719
-   ╭─[4:26]
+   ╭─[tests/test-data.txt:4:26]
  3 │ 
  4 │ mdi-file_document_box = ""
    ·                          ┬
@@ -26,7 +26,7 @@
           4. 󱪗 U+F1A97 md-file_document_alert
 
   ☞ Found obsolete icon U+F719
-   ╭─[8:26]
+   ╭─[tests/test-data.txt:8:26]
  7 │ # Test autofix from histroy
  8 │ mdi-file_document_box = ""
    ·                          ┬
@@ -40,7 +40,7 @@
           4. 󱪗 U+F1A97 md-file_document_alert
 
   ☞ Found obsolete icon U+F7A1
-    ╭─[11:12]
+    ╭─[tests/test-data.txt:11:12]
  10 │ 
  11 │ mdi-git = "",
     ·            ┬
@@ -52,7 +52,7 @@
           2.  U+0E65D seti-git
 
   ☞ Found obsolete icon U+F9E8
-    ╭─[14:12]
+    ╭─[tests/test-data.txt:14:12]
  13 │ 
  14 │ mdi-tab = "裡"
     ·            ─┬
@@ -63,7 +63,7 @@
           1. 󰓩 U+F04E9 md-tab
 
   ☞ Found obsolete icon U+FC0A
-    ╭─[17:24]
+    ╭─[tests/test-data.txt:17:24]
  16 │ 
  17 │ mdi-rhombus_outline = "ﰊ"
     ·                        ┬
@@ -77,7 +77,7 @@
           4. 󱓝 U+F14DD md-rhombus_split_outline
 
   ☞ Found obsolete icon U+F554
-    ╭─[20:26]
+    ╭─[tests/test-data.txt:20:26]
  19 │ 
  20 │ mdi-arrow_right_thick = ""
     ·                          ┬

--- a/tests/cli/check_json.stderr
+++ b/tests/cli/check_json.stderr
@@ -1,1 +1,1 @@
- INFO Check input file from 'tests/test-data.txt'
+ INFO Check input from 'tests/test-data.txt'

--- a/tests/cli/check_with_db.stderr
+++ b/tests/cli/check_with_db.stderr
@@ -1,2 +1,2 @@
  INFO Load input from 'tests/test-icons.json'
- INFO Check input file from 'tests/test-data.txt'
+ INFO Check input from 'tests/test-data.txt'

--- a/tests/cli/check_with_db.stdout
+++ b/tests/cli/check_with_db.stdout
@@ -1,5 +1,5 @@
   ☞ Found obsolete icon U+F719
-   ╭─[4:26]
+   ╭─[tests/test-data.txt:4:26]
  3 │ 
  4 │ mdi-file_document_box = ""
    ·                          ┬
@@ -10,7 +10,7 @@
           1. 󰈙 U+F0219 md-file_document
 
   ☞ Found obsolete icon U+F719
-   ╭─[8:26]
+   ╭─[tests/test-data.txt:8:26]
  7 │ # Test autofix from histroy
  8 │ mdi-file_document_box = ""
    ·                          ┬

--- a/tests/cli/fix.stderr
+++ b/tests/cli/fix.stderr
@@ -1,6 +1,6 @@
- INFO Check input file from 'tests/test-data.txt'
+ INFO Check input from 'tests/test-data.txt'
   ☞ Found obsolete icon U+F752
-   ╭─[1:24]
+   ╭─[tests/test-data.txt:1:24]
  1 │ mdi-folder_multiple = ""
    ·                        ┬
    ·                        ╰── Icon 'mdi-folder_multiple' is marked as obsolete
@@ -14,7 +14,7 @@
 
 # Autofix with substitution '󰉓'
   ☞ Found obsolete icon U+F719
-   ╭─[4:26]
+   ╭─[tests/test-data.txt:4:26]
  3 │ 
  4 │ mdi-file_document_box = ""
    ·                          ┬
@@ -29,7 +29,7 @@
 
 # Autofix with the first suggestion '󰈙'
   ☞ Found obsolete icon U+F719
-   ╭─[8:26]
+   ╭─[tests/test-data.txt:8:26]
  7 │ # Test autofix from histroy
  8 │ mdi-file_document_box = ""
    ·                          ┬
@@ -44,7 +44,7 @@
 
 # Autofix with the first suggestion '󰈙'
   ☞ Found obsolete icon U+F7A1
-    ╭─[11:12]
+    ╭─[tests/test-data.txt:11:12]
  10 │ 
  11 │ mdi-git = "",
     ·            ┬
@@ -57,7 +57,7 @@
 
 # Autofix with substitution '󰊢'
   ☞ Found obsolete icon U+F9E8
-    ╭─[14:12]
+    ╭─[tests/test-data.txt:14:12]
  13 │ 
  14 │ mdi-tab = "裡"
     ·            ─┬
@@ -69,7 +69,7 @@
 
 # Autofix with substitution '󰓩'
   ☞ Found obsolete icon U+FC0A
-    ╭─[17:24]
+    ╭─[tests/test-data.txt:17:24]
  16 │ 
  17 │ mdi-rhombus_outline = "ﰊ"
     ·                        ┬
@@ -84,7 +84,7 @@
 
 # Autofix with substitution '󰜌'
   ☞ Found obsolete icon U+F554
-    ╭─[20:26]
+    ╭─[tests/test-data.txt:20:26]
  19 │ 
  20 │ mdi-arrow_right_thick = ""
     ·                          ┬

--- a/tests/cli/fix_with_exact_subs.stderr
+++ b/tests/cli/fix_with_exact_subs.stderr
@@ -1,8 +1,8 @@
  INFO Load input from 'src/icons.json'
  INFO Load input from 'tests/test-substitutions.json'
- INFO Check input file from 'tests/test-data.txt'
+ INFO Check input from 'tests/test-data.txt'
   ☞ Found obsolete icon U+F752
-   ╭─[1:24]
+   ╭─[tests/test-data.txt:1:24]
  1 │ mdi-folder_multiple = ""
    ·                        ┬
    ·                        ╰── Icon 'mdi-folder_multiple' is marked as obsolete
@@ -16,7 +16,7 @@
 
 # Autofix with the first suggestion '󰉓'
   ☞ Found obsolete icon U+F719
-   ╭─[4:26]
+   ╭─[tests/test-data.txt:4:26]
  3 │ 
  4 │ mdi-file_document_box = ""
    ·                          ┬
@@ -31,7 +31,7 @@
 
 # Autofix with substitution '󰈙'
   ☞ Found obsolete icon U+F719
-   ╭─[8:26]
+   ╭─[tests/test-data.txt:8:26]
  7 │ # Test autofix from histroy
  8 │ mdi-file_document_box = ""
    ·                          ┬
@@ -46,7 +46,7 @@
 
 # Autofix with substitution '󰈙'
   ☞ Found obsolete icon U+F7A1
-    ╭─[11:12]
+    ╭─[tests/test-data.txt:11:12]
  10 │ 
  11 │ mdi-git = "",
     ·            ┬
@@ -59,7 +59,7 @@
 
 # Autofix with the first suggestion '󰊢'
   ☞ Found obsolete icon U+F9E8
-    ╭─[14:12]
+    ╭─[tests/test-data.txt:14:12]
  13 │ 
  14 │ mdi-tab = "裡"
     ·            ─┬
@@ -71,7 +71,7 @@
 
 # Autofix with the first suggestion '󰓩'
   ☞ Found obsolete icon U+FC0A
-    ╭─[17:24]
+    ╭─[tests/test-data.txt:17:24]
  16 │ 
  17 │ mdi-rhombus_outline = "ﰊ"
     ·                        ┬
@@ -86,7 +86,7 @@
 
 # Autofix with the first suggestion '󰜌'
   ☞ Found obsolete icon U+F554
-    ╭─[20:26]
+    ╭─[tests/test-data.txt:20:26]
  19 │ 
  20 │ mdi-arrow_right_thick = ""
     ·                          ┬

--- a/tests/cli/fix_with_prefix_subs.stderr
+++ b/tests/cli/fix_with_prefix_subs.stderr
@@ -1,7 +1,7 @@
  INFO Load input from 'src/icons.json'
- INFO Check input file from 'tests/test-data.txt'
+ INFO Check input from 'tests/test-data.txt'
   ☞ Found obsolete icon U+F752
-   ╭─[1:24]
+   ╭─[tests/test-data.txt:1:24]
  1 │ mdi-folder_multiple = ""
    ·                        ┬
    ·                        ╰── Icon 'mdi-folder_multiple' is marked as obsolete
@@ -15,7 +15,7 @@
 
 # Autofix with substitution '󰉓'
   ☞ Found obsolete icon U+F719
-   ╭─[4:26]
+   ╭─[tests/test-data.txt:4:26]
  3 │ 
  4 │ mdi-file_document_box = ""
    ·                          ┬
@@ -30,7 +30,7 @@
 
 # Autofix with the first suggestion '󰈙'
   ☞ Found obsolete icon U+F719
-   ╭─[8:26]
+   ╭─[tests/test-data.txt:8:26]
  7 │ # Test autofix from histroy
  8 │ mdi-file_document_box = ""
    ·                          ┬
@@ -45,7 +45,7 @@
 
 # Autofix with the first suggestion '󰈙'
   ☞ Found obsolete icon U+F7A1
-    ╭─[11:12]
+    ╭─[tests/test-data.txt:11:12]
  10 │ 
  11 │ mdi-git = "",
     ·            ┬
@@ -58,7 +58,7 @@
 
 # Autofix with substitution '󰊢'
   ☞ Found obsolete icon U+F9E8
-    ╭─[14:12]
+    ╭─[tests/test-data.txt:14:12]
  13 │ 
  14 │ mdi-tab = "裡"
     ·            ─┬
@@ -70,7 +70,7 @@
 
 # Autofix with substitution '󰓩'
   ☞ Found obsolete icon U+FC0A
-    ╭─[17:24]
+    ╭─[tests/test-data.txt:17:24]
  16 │ 
  17 │ mdi-rhombus_outline = "ﰊ"
     ·                        ┬
@@ -85,7 +85,7 @@
 
 # Autofix with substitution '󰜌'
   ☞ Found obsolete icon U+F554
-    ╭─[20:26]
+    ╭─[tests/test-data.txt:20:26]
  19 │ 
  20 │ mdi-arrow_right_thick = ""
     ·                          ┬


### PR DESCRIPTION
Source paths have disappeared since #21, this PR adds them back.