### PR TITLE
feat(cli): support generating shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,9 +171,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -192,10 +192,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_derive"
-version = "4.4.7"
+name = "clap_complete"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "d9647a559c112175f17cf724dc72d3645680a883c58481332779192b0d8e7a01"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -205,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "codespan-reporting"
@@ -380,9 +389,9 @@ checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
@@ -544,6 +553,7 @@ dependencies = [
  "bytesize",
  "camino",
  "clap",
+ "clap_complete",
  "codespan-reporting",
  "content_inspector",
  "extend",
@@ -924,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "supports-color"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ rust-version = "1.75"
 [dependencies]
 bytesize = "1.3"
 camino = "1.1"
-clap = { version = ">=4.0, <4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
+clap_complete = "4.5"
 codespan-reporting = "0.11.1"
 content_inspector = "0.2.4"
 extend = "1.2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ use std::{fmt, fs, io};
 use bytesize::ByteSize;
 use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
 use shadow_rs::formatcp;
 use thisctx::IntoError;
 
@@ -14,11 +15,12 @@ use crate::icon::Substitution;
 use crate::input::InputReader;
 use crate::{error, shadow};
 
+const V_FORMAT: &str = "FORMAT";
 const V_PATH: &str = "PATH";
+const V_SHELL: &str = "SHELL";
+const V_SIZE: &str = "SIZE";
 const V_SOURCE: &str = "SOURCE";
 const V_SUBSTITUTION: &str = "SUBSTITUTION";
-const V_FORMAT: &str = "FORMAT";
-const V_SIZE: &str = "SIZE";
 const DEFAULT_SIZE: &str = "16MB";
 const INDEX_REV: &str = include_str!("index-rev");
 const CLAP_LONG_VERSION: &str = formatcp!("{}\ncheat-sheet: {}", shadow::PKG_VERSION, INDEX_REV);
@@ -140,6 +142,11 @@ pub enum Command {
     },
     /// Fuzzy search for an icon.
     Search {},
+    /// Generate shell completions for your shell to stdout.
+    Completions {
+        #[arg(value_name = V_SHELL)]
+        shell: Shell,
+    },
 }
 
 #[derive(Clone, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,14 @@ fn main_impl() -> error::Result<()> {
         Command::Search {} => {
             rt.build().prompt_input_icon(None).ok();
         }
+        Command::Completions { shell } => {
+            clap_complete::generate(
+                shell,
+                &mut <cli::Cli as clap::CommandFactory>::command(),
+                shadow::PROJECT_NAME,
+                &mut std::io::stdout(),
+            );
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
Added a subcommand, `nerdfix completions <SHELL>`, to generate completions for your shell.

Closes #28