### PR TITLE
refactor(cli): merge `query` subcommand into `search`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,11 @@ are noticeable to end-users since the last release. For developers, this project
 
 - Add a subcommand, `nerdfix completions <SHELL>`, to generate completions for your shell ([#30]).
 - Support comments in JSON files ([#33]).
-- Add a new `nerdfix query` subcommand, useful for querying icon infos from the database ([#33]).
 - Add a new `codepoint:from/to` substitution type ([#33]).
 - Support checking dropped icons of Nerd Fonts v3.3.0 through the newly added `nerdfix --nf-version=3.3.0` option
   ([#33], thanks [@Finii] and [@hasecilu]).
+- Add two new options, `--codepoint` and `--name`, for `nerdfix search`, useful for querying icon infos from the
+  database non-interactively ([#??]).
 
 [#30]: https://github.com/loichyan/nerdfix/pull/30
 [#33]: https://github.com/loichyan/nerdfix/pull/33

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,7 +74,7 @@ pub struct Cli {
     #[command(subcommand)]
     pub cmd: Command,
     /// [deprecated] Use `--input` instead.
-    #[arg(long, global = true, value_name = V_SUB)]
+    #[arg(long, global = true, value_name = V_PATH)]
     pub substitution: Vec<IoPath>,
     /// [deprecated] Use `--sub prefix:` instead.
     #[arg(long, global = true, value_name = V_SUB)]
@@ -145,12 +145,15 @@ pub enum Command {
         #[arg(value_name = V_SOURCE)]
         source: Vec<IoPath>,
     },
-    /// Fuzzy search for an icon.
-    Search {},
-    /// Query icon infos from the database, returned in JSON.
-    Query {
+    /// Query icon infos from the database.
+    ///
+    /// If no argument is specified, it will open a prompt for interactive fuzzy
+    /// search.
+    Search {
+        /// Search for icon of the given codepoint, returned in JSON if matches.
         #[arg(long, value_parser = crate::icon::parse_codepoint)]
         codepoint: Option<char>,
+        /// Search for icon of the given name, returned in JSON if matches.
         #[arg(long, conflicts_with = "codepoint")]
         name: Option<String>,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,16 +196,14 @@ fn main_impl() -> error::Result<()> {
                 .log_error();
             }
         }
-        Command::Search {} => {
-            rt.build().prompt_input_icon(None).ok();
-        }
-        Command::Query { codepoint, name } => {
+        Command::Search { codepoint, name } => {
             let rt = rt.build();
             let icon = if let Some(c) = codepoint {
                 rt.get_icon_by_codepoint(c)
             } else if let Some(name) = name {
                 rt.get_icon_by_name(&name)
             } else {
+                rt.prompt_input_icon(None).ok();
                 None
             };
             if let Some(icon) = icon {


### PR DESCRIPTION
Moves the functionalities of the `nerdfix query` subcommand, added in #33, into `nerdfix search`.