### PR TITLE
chore(release): v0.4.2

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -184,6 +184,9 @@ jobs:
       contents: write # need to update release
     runs-on: ubuntu-latest
     steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v4
+
       - name: Setup | Configure
         id: configure
         run: echo tag="${GITHUB_HEAD_REF#release/}" >$GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,11 @@ are noticeable to end-users since the last release. For developers, this project
 - Support checking dropped icons of Nerd Fonts v3.3.0 through the newly added `nerdfix --nf-version=3.3.0` option
   ([#33], thanks [@Finii] and [@hasecilu]).
 - Add two new options, `--codepoint` and `--name`, for `nerdfix search`, useful for querying icon infos from the
-  database non-interactively ([#??]).
+  database non-interactively ([#34]).
 
 [#30]: https://github.com/loichyan/nerdfix/pull/30
 [#33]: https://github.com/loichyan/nerdfix/pull/33
+[#34]: https://github.com/loichyan/nerdfix/pull/34
 [@Finii]: https://github.com/Finii
 [@hasecilu]: https://github.com/hasecilu
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ are noticeable to end-users since the last release. For developers, this project
 
 ## [Unreleased]
 
+## [0.4.2] - 2024-11-23
+
 ### Added
 
 - Add a subcommand, `nerdfix completions <SHELL>`, to generate completions for your shell ([#30]).
@@ -228,7 +230,8 @@ UX breaking changes. Here are some guides for migrating from `v0.3`:
 
 🎉 Initial release. See [README](https://github.com/loichyan/nerdfix/blob/v0.1.0/README.md) for more details.
 
-[Unreleased]: https://github.com/loichyan/nerdfix/compare/v0.4.1..HEAD
+[Unreleased]: https://github.com/loichyan/nerdfix/compare/v0.4.2..HEAD
+[0.4.2]: https://github.com/loichyan/nerdfix/compare/v0.4.1..v0.4.2
 [0.4.1]: https://github.com/loichyan/nerdfix/compare/v0.4.0..v0.4.1
 [0.4.0]: https://github.com/loichyan/nerdfix/compare/v0.3.1..v0.4.0
 [0.3.1]: https://github.com/loichyan/nerdfix/compare/v0.3.0..v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "nerdfix"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "assert_cmd",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nerdfix"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Loi Chyan <loichyan@foxmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
### Added

- Add a subcommand, `nerdfix completions <SHELL>`, to generate completions for your shell ([#30]).
- Support comments in JSON files ([#33]).
- Add a new `codepoint:from/to` substitution type ([#33]).
- Support checking dropped icons of Nerd Fonts v3.3.0 through the newly added `nerdfix --nf-version=3.3.0` option ([#33]).
- Add two new options, `--codepoint` and `--name`, for `nerdfix search`, useful for querying icon infos from the database non-interactively ([#34]).

[#30]: https://github.com/loichyan/nerdfix/pull/30
[#33]: https://github.com/loichyan/nerdfix/pull/33
[#34]: https://github.com/loichyan/nerdfix/pull/34
[@Finii]: https://github.com/Finii
[@hasecilu]: https://github.com/hasecilu
